### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+# Part of Neubot <https://neubot.nexacenter.org/>.
+# Neubot is free software. See AUTHORS and LICENSE for more
+# information on the copying conditions.
+
+from distutils.core import setup
+
+setup(name='neubot-runtime',
+      version='0.4.17.0',
+      description='Neubot Runtime Library',
+      author='Simone Basso, et al.',
+      author_email='bassosimone@gmail.com',
+      url='https://neubot.nexacenter.org/',
+      packages=['neubot_runtime'],
+     )


### PR DESCRIPTION
With this file committed, we could install neubot-runtime from inside another repository by following this simple procedure (and without having to keep a forked copy of the sources):

```
virtualenv VENV
source VENV/bin/activate
pip install https://github.com/neubot/neubot-runtime/archive/stable.zip
```

Tested locally with a different `pip install` command tailored to use this branch rather than `stable`.
